### PR TITLE
Refactor provider types and extract handoff utils

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,6 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
-  "organizeImports": {
-    "enabled": true
-  },
+  "$schema": "https://biomejs.dev/schemas/2.4.5/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {
@@ -19,6 +17,6 @@
     "lineWidth": 100
   },
   "files": {
-    "ignore": ["dist/", "node_modules/"]
+    "includes": ["**", "!**/dist/", "!**/node_modules/"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ci": "bun run check && bun run lint"
   },
   "dependencies": {
-    "zod": "^4.3.6"
+    "zod": "^4.0.0"
   },
   "peerDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.68",

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,4 +1,4 @@
-import type { AgentDef, ToolDef, McpServerConfig } from "./types.js";
+import type { AgentDef, McpServerConfig, ToolDef } from "./types.js";
 
 /** Convenience helper to define an agent with type checking */
 export function defineAgent(config: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,22 @@
 // Core types
-export type {
-  ToolDef,
-  AgentDef,
-  McpServerConfig,
-  StreamChunk,
-  RunConfig,
-  AgentRun,
-} from "./types.js";
-
-// Provider interface
-export type { Provider } from "./providers/types.js";
 
 // Helpers
 export { defineAgent } from "./agent.js";
-export { defineTool } from "./tool.js";
 
+// Provider backend interface
+export type { ProviderBackend } from "./providers/types.js";
 // Runner
 export { run, runToCompletion } from "./runner.js";
+export { defineTool } from "./tool.js";
+export type {
+  AgentDef,
+  AgentRun,
+  McpServerConfig,
+  Provider,
+  RunConfig,
+  StreamChunk,
+  ToolDef,
+} from "./types.js";
 
 // Utilities
 export { zodToJsonSchema } from "./utils/zod-to-jsonschema.js";

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -1,15 +1,13 @@
-import type { Provider } from "./types.js";
-import type { StreamChunk, RunConfig, ToolDef, AgentDef } from "../types.js";
+import type { AgentDef, RunConfig, StreamChunk, ToolDef } from "../types.js";
+import type { ProviderBackend } from "./types.js";
 
-export async function createClaudeProvider(
-  config: RunConfig
-): Promise<Provider> {
+export async function createClaudeProvider(config: RunConfig): Promise<ProviderBackend> {
   let claudeSdk: any;
   try {
     claudeSdk = await import("@anthropic-ai/claude-agent-sdk");
   } catch {
     throw new Error(
-      'Claude provider requires @anthropic-ai/claude-agent-sdk. Install it with: bun add @anthropic-ai/claude-agent-sdk'
+      "Claude provider requires @anthropic-ai/claude-agent-sdk. Install it with: bun add @anthropic-ai/claude-agent-sdk",
     );
   }
 
@@ -29,12 +27,10 @@ export async function createClaudeProvider(
         tool(t.name, t.description, t.parameters, async (args: any) => {
           const result = await t.handler(args);
           return { content: [{ type: "text" as const, text: result }] };
-        })
+        }),
       ),
     });
-    toolNames = agentTools.map(
-      (t: ToolDef) => `mcp__${serverName}__${t.name}`
-    );
+    toolNames = agentTools.map((t: ToolDef) => `mcp__${serverName}__${t.name}`);
   }
 
   // Merge MCP servers: user-tool server + agent-level + run-level
@@ -46,10 +42,11 @@ export async function createClaudeProvider(
   // Build agent definitions for handoffs
   let agents: any[] | undefined;
   if (config.agent.handoffs?.length && config.agents) {
+    const agentsMap = config.agents;
     agents = config.agent.handoffs
-      .map((name) => config.agents![name])
-      .filter(Boolean)
-      .map((a: AgentDef) => ({
+      .map((name) => agentsMap[name])
+      .filter((a): a is AgentDef => !!a)
+      .map((a) => ({
         name: a.name,
         description: a.description,
         instructions: a.prompt,
@@ -105,10 +102,7 @@ export async function createClaudeProvider(
         yield {
           type: "tool_result",
           toolCallId: msg.tool_use_id ?? "",
-          result:
-            typeof msg.content === "string"
-              ? msg.content
-              : JSON.stringify(msg.content),
+          result: typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content),
         };
       }
     }

--- a/src/providers/kimi.ts
+++ b/src/providers/kimi.ts
@@ -1,15 +1,14 @@
-import type { Provider } from "./types.js";
-import type { StreamChunk, RunConfig, ToolDef, AgentDef } from "../types.js";
+import type { RunConfig, StreamChunk, ToolDef } from "../types.js";
+import { handoffToolName, parseHandoff } from "../utils/handoff.js";
+import type { ProviderBackend } from "./types.js";
 
-export async function createKimiProvider(
-  config: RunConfig
-): Promise<Provider> {
+export async function createKimiProvider(config: RunConfig): Promise<ProviderBackend> {
   let kimiSdk: any;
   try {
     kimiSdk = await import("@moonshot-ai/kimi-agent-sdk");
   } catch {
     throw new Error(
-      'Kimi provider requires @moonshot-ai/kimi-agent-sdk. Install it with: bun add @moonshot-ai/kimi-agent-sdk'
+      "Kimi provider requires @moonshot-ai/kimi-agent-sdk. Install it with: bun add @moonshot-ai/kimi-agent-sdk",
     );
   }
 
@@ -27,7 +26,7 @@ export async function createKimiProvider(
         const result = await t.handler(params);
         return { output: result, message: "ok" };
       },
-    })
+    }),
   );
 
   // Add synthetic handoff tools
@@ -37,13 +36,13 @@ export async function createKimiProvider(
     const targetAgent = config.agents?.[targetName];
     externalTools.push(
       createExternalTool({
-        name: `transfer_to_${targetName}`,
+        name: handoffToolName(targetName),
         description: targetAgent?.description ?? `Transfer to ${targetName}`,
         parameters: {} as any,
         handler: async () => {
           return { output: `Transferred to ${targetName}`, message: "ok" };
         },
-      })
+      }),
     );
   }
 
@@ -77,14 +76,14 @@ export async function createKimiProvider(
         };
 
         // Check for handoff
-        if (name.startsWith("transfer_to_")) {
-          const targetName = name.slice("transfer_to_".length);
-          const targetAgent = config.agents?.[targetName];
+        const handoffTarget = parseHandoff(name);
+        if (handoffTarget) {
+          const targetAgent = config.agents?.[handoffTarget];
           if (targetAgent) {
             yield {
               type: "handoff",
               fromAgent: currentAgent.name,
-              toAgent: targetName,
+              toAgent: handoffTarget,
             };
             currentAgent = targetAgent;
           }

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -1,18 +1,15 @@
-import type { Provider } from "./types.js";
-import type { StreamChunk, RunConfig, ToolDef, AgentDef } from "../types.js";
+import type { AgentDef, RunConfig, StreamChunk, ToolDef } from "../types.js";
+import { handoffToolName, parseHandoff } from "../utils/handoff.js";
 import { zodToJsonSchema } from "../utils/zod-to-jsonschema.js";
+import type { ProviderBackend } from "./types.js";
 
-export async function createOpenAIProvider(
-  config: RunConfig
-): Promise<Provider> {
+export async function createOpenAIProvider(config: RunConfig): Promise<ProviderBackend> {
   let OpenAI: any;
   try {
     const mod = await import("openai");
     OpenAI = mod.default;
   } catch {
-    throw new Error(
-      'OpenAI provider requires the openai package. Install it with: bun add openai'
-    );
+    throw new Error("OpenAI provider requires the openai package. Install it with: bun add openai");
   }
 
   const apiKey = (config.providerOptions?.apiKey as string) ?? undefined;
@@ -42,7 +39,7 @@ export async function createOpenAIProvider(
       tools.push({
         type: "function",
         function: {
-          name: `transfer_to_${targetName}`,
+          name: handoffToolName(targetName),
           description: targetAgent?.description ?? `Transfer to ${targetName}`,
           parameters: { type: "object", properties: {} },
         },
@@ -82,10 +79,7 @@ export async function createOpenAIProvider(
 
       // Accumulate the streamed response
       let assistantContent = "";
-      const toolCalls: Map<
-        number,
-        { id: string; name: string; arguments: string }
-      > = new Map();
+      const toolCalls: Map<number, { id: string; name: string; arguments: string }> = new Map();
 
       for await (const chunk of stream) {
         const delta = chunk.choices[0]?.delta;
@@ -106,8 +100,7 @@ export async function createOpenAIProvider(
             };
             if (tc.id) existing.id = tc.id;
             if (tc.function?.name) existing.name = tc.function.name;
-            if (tc.function?.arguments)
-              existing.arguments += tc.function.arguments;
+            if (tc.function?.arguments) existing.arguments += tc.function.arguments;
             toolCalls.set(tc.index, existing);
           }
         }
@@ -148,8 +141,9 @@ export async function createOpenAIProvider(
         };
 
         // Check if this is a handoff
-        if (tc.name.startsWith("transfer_to_")) {
-          const targetName = tc.name.slice("transfer_to_".length);
+        const handoffTarget = parseHandoff(tc.name);
+        if (handoffTarget) {
+          const targetName = handoffTarget;
           const targetAgent = config.agents?.[targetName];
 
           if (targetAgent) {

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,7 +1,7 @@
-import type { StreamChunk, RunConfig } from "../types.js";
+import type { RunConfig, StreamChunk } from "../types.js";
 
-/** Provider interface — all backends implement this */
-export interface Provider {
+/** Provider backend interface — all backends implement this */
+export interface ProviderBackend {
   run(prompt: string, config: RunConfig): AsyncGenerator<StreamChunk>;
   chat(message: string): AsyncGenerator<StreamChunk>;
   close(): Promise<void>;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,7 +1,7 @@
-import type { RunConfig, AgentRun, StreamChunk } from "./types.js";
-import type { Provider } from "./providers/types.js";
+import type { ProviderBackend } from "./providers/types.js";
+import type { AgentRun, RunConfig } from "./types.js";
 
-async function createProvider(config: RunConfig): Promise<Provider> {
+async function createProvider(config: RunConfig): Promise<ProviderBackend> {
   switch (config.provider) {
     case "claude": {
       const { createClaudeProvider } = await import("./providers/claude.js");
@@ -16,9 +16,7 @@ async function createProvider(config: RunConfig): Promise<Provider> {
       return createKimiProvider(config);
     }
     default:
-      throw new Error(
-        `Unknown provider: ${config.provider}. Use: claude, openai, kimi`
-      );
+      throw new Error(`Unknown provider: ${config.provider}. Use: claude, openai, kimi`);
   }
 }
 
@@ -35,10 +33,7 @@ export async function run(prompt: string, config: RunConfig): Promise<AgentRun> 
 }
 
 /** Convenience: run to completion and return collected text */
-export async function runToCompletion(
-  prompt: string,
-  config: RunConfig
-): Promise<string> {
+export async function runToCompletion(prompt: string, config: RunConfig): Promise<string> {
   const provider = await createProvider(config);
   let text = "";
 

--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -8,7 +8,7 @@ declare module "@anthropic-ai/claude-agent-sdk" {
     name: string,
     description: string,
     parameters: any,
-    handler: (args: any) => Promise<any>
+    handler: (args: any) => Promise<any>,
   ): any;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,9 +45,12 @@ export type StreamChunk =
       usage?: { inputTokens: number; outputTokens: number };
     };
 
+/** Supported provider backends */
+export type Provider = "claude" | "openai" | "kimi";
+
 /** Configuration for a run */
 export interface RunConfig {
-  provider: "claude" | "openai" | "kimi";
+  provider: Provider;
   agent: AgentDef;
   /** Additional agents for handoffs */
   agents?: Record<string, AgentDef>;

--- a/src/utils/handoff.ts
+++ b/src/utils/handoff.ts
@@ -1,0 +1,9 @@
+const HANDOFF_PREFIX = "transfer_to_";
+
+export function handoffToolName(agentName: string): string {
+  return `${HANDOFF_PREFIX}${agentName}`;
+}
+
+export function parseHandoff(toolName: string): string | null {
+  return toolName.startsWith(HANDOFF_PREFIX) ? toolName.slice(HANDOFF_PREFIX.length) : null;
+}


### PR DESCRIPTION
## Summary
- Extract `Provider` string union type from inline literal in `RunConfig`
- Rename internal `Provider` interface to `ProviderBackend` to disambiguate from the public type
- Extract `transfer_to_` handoff prefix into shared `src/utils/handoff.ts` with `handoffToolName()` and `parseHandoff()` helpers
- Widen zod dependency to `^4.0.0` for broader compatibility
- Migrate biome config from 2.0.0 to 2.4.5
- Fix non-null assertion in claude provider with proper type guard
- Remove unused imports and auto-fix formatting

## Test plan
- [x] `bun run check` passes
- [x] `bun run lint` passes