### PR TITLE
Add files field for npm publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "files": [
+    "dist",
+    "src"
+  ],
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",


### PR DESCRIPTION
## Summary
- Add `files` field to `package.json` to limit published package to `dist/` and `src/` directories
- Prevents `node_modules`, `examples`, config files, etc. from being included in the npm tarball

## Test plan
- [ ] Verify with `npm pack --dry-run`