### PR TITLE
Fix Claude provider nested session and abort handling

### DIFF
--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -57,9 +57,15 @@ export async function createClaudeProvider(config: RunConfig): Promise<ProviderB
   let sessionId: string | undefined;
 
   async function* runQuery(prompt: string): AsyncGenerator<StreamChunk> {
+    // Unset CLAUDECODE to allow spawning a Claude Code subprocess
+    // (the SDK refuses to nest inside an existing Claude Code session)
+    const env = { ...process.env, CLAUDECODE: undefined };
+
     const options: Record<string, unknown> = {
       systemPrompt: config.agent.prompt,
       permissionMode: "bypassPermissions",
+      allowDangerouslySkipPermissions: true,
+      env,
     };
 
     if (config.agent.model) options.model = config.agent.model;
@@ -68,6 +74,11 @@ export async function createClaudeProvider(config: RunConfig): Promise<ProviderB
     if (agents) options.agents = agents;
     if (sessionId) options.resume = sessionId;
     if (config.maxTurns) options.maxTurns = config.maxTurns;
+    if (config.signal) {
+      const ac = new AbortController();
+      config.signal.addEventListener("abort", () => ac.abort());
+      options.abortController = ac;
+    }
     if (config.providerOptions) Object.assign(options, config.providerOptions);
 
     let fullText = "";
@@ -75,7 +86,6 @@ export async function createClaudeProvider(config: RunConfig): Promise<ProviderB
     for await (const msg of query({
       prompt,
       options: options as any,
-      signal: config.signal,
     })) {
       if (msg.type === "system" && msg.subtype === "init") {
         sessionId = msg.session_id;


### PR DESCRIPTION
## Summary
- Unset `CLAUDECODE` env var when spawning the agent SDK subprocess, fixing "cannot be launched inside another Claude Code session" error
- Add `allowDangerouslySkipPermissions: true` (required when using `bypassPermissions` mode)
- Bridge `config.signal` (AbortSignal) to the SDK's `abortController` option
- Remove invalid `signal` parameter from `query()` call

## Test plan
- [x] Tested basic tool use (weather tool) — agent calls tool and returns result
- [x] Tested multi-agent setup (researcher + math) — agent uses tools correctly
- [ ] OpenAI provider untested (no API key in env; would need to run inside Codex or set `OPENAI_API_KEY`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)