### PR TITLE
Fix publish workflow: allow same version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
       - run: bun run build
 
       - name: Set version
-        run: npm version ${{ inputs.version }} --no-git-tag-version
+        run: npm version ${{ inputs.version }} --no-git-tag-version --allow-same-version
 
       - name: Commit, tag, and push
         run: |


### PR DESCRIPTION
## Summary
- Add `--allow-same-version` to `npm version` command to prevent failure when `package.json` already has the target version