### PR TITLE
feat: add provider registry for custom backends

### DIFF
--- a/src/__tests__/registry.test.ts
+++ b/src/__tests__/registry.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { clearProviders, getProvider, registerProvider } from "../registry.js";
+import { run } from "../runner.js";
+import type { AgentDef } from "../types.js";
+import { createMockProvider } from "./mock-provider.js";
+
+const agent: AgentDef = {
+  name: "test-agent",
+  description: "A test agent",
+  prompt: "You are a test assistant.",
+};
+
+afterEach(() => {
+  clearProviders();
+});
+
+describe("registerProvider / getProvider", () => {
+  test("registerProvider makes a custom provider available", () => {
+    const { provider } = createMockProvider();
+    registerProvider("my-llm", async () => provider);
+    expect(getProvider("my-llm")).toBeDefined();
+  });
+
+  test("getProvider returns undefined for unknown name", () => {
+    expect(getProvider("unknown")).toBeUndefined();
+  });
+
+  test("clearProviders removes all registered providers", () => {
+    const { provider } = createMockProvider();
+    registerProvider("a", async () => provider);
+    registerProvider("b", async () => provider);
+    clearProviders();
+    expect(getProvider("a")).toBeUndefined();
+    expect(getProvider("b")).toBeUndefined();
+  });
+
+  test("custom provider overrides built-in if same name is used", async () => {
+    const { provider, calls } = createMockProvider([{ type: "done" }]);
+    registerProvider("claude", async () => provider);
+    const handle = await run("hello", { provider: "claude", agent });
+    for await (const _ of handle.stream) {
+      // drain
+    }
+    expect(calls.length).toBe(1);
+    await handle.close();
+  });
+});
+
+describe("run() with registered provider", () => {
+  test("uses custom provider when its name is given", async () => {
+    const { provider, calls } = createMockProvider([
+      { type: "text", text: "hello from mock" },
+      { type: "done" },
+    ]);
+    registerProvider("custom-provider", async () => provider);
+
+    const handle = await run("hi", { provider: "custom-provider", agent });
+    const chunks: string[] = [];
+    for await (const chunk of handle.stream) {
+      if (chunk.type === "text") chunks.push(chunk.text);
+    }
+    await handle.close();
+
+    expect(calls.length).toBe(1);
+    expect(calls[0].prompt).toBe("hi");
+    expect(chunks).toEqual(["hello from mock"]);
+  });
+
+  test("unknown provider throws helpful error", async () => {
+    await expect(run("hello", { provider: "no-such-provider", agent })).rejects.toThrow(
+      "Unknown provider: no-such-provider",
+    );
+    await expect(run("hello", { provider: "no-such-provider", agent })).rejects.toThrow(
+      "registerProvider()",
+    );
+  });
+
+  test("built-in provider names remain valid type-level values", () => {
+    // This is a compile-time check — just ensure the type assignment works
+    const p1: import("../types.js").BuiltinProvider = "claude";
+    const p2: import("../types.js").BuiltinProvider = "codex";
+    const p3: import("../types.js").BuiltinProvider = "kimi";
+    expect([p1, p2, p3]).toEqual(["claude", "codex", "kimi"]);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,12 +5,16 @@ export { defineAgent } from "./agent.js";
 
 // Provider backend interface
 export type { ProviderBackend } from "./providers/types.js";
+export type { ProviderFactory } from "./registry.js";
+// Registry
+export { clearProviders, registerProvider } from "./registry.js";
 // Runner
 export { run, runToCompletion } from "./runner.js";
 export { defineTool } from "./tool.js";
 export type {
   AgentDef,
   AgentRun,
+  BuiltinProvider,
   McpServerConfig,
   Provider,
   RunConfig,

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,21 @@
+import type { ProviderBackend } from "./providers/types.js";
+import type { RunConfig } from "./types.js";
+
+export type ProviderFactory = (config: RunConfig) => Promise<ProviderBackend>;
+
+const registry = new Map<string, ProviderFactory>();
+
+/** Register a custom provider */
+export function registerProvider(name: string, factory: ProviderFactory): void {
+  registry.set(name, factory);
+}
+
+/** Get a registered provider factory (returns undefined if not found) */
+export function getProvider(name: string): ProviderFactory | undefined {
+  return registry.get(name);
+}
+
+/** Clear all registered providers (useful for testing) */
+export function clearProviders(): void {
+  registry.clear();
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,7 +1,13 @@
 import type { ProviderBackend } from "./providers/types.js";
+import { getProvider } from "./registry.js";
 import type { AgentRun, RunConfig } from "./types.js";
 
 async function createProvider(config: RunConfig): Promise<ProviderBackend> {
+  // Check registry first (custom providers)
+  const factory = getProvider(config.provider);
+  if (factory) return factory(config);
+
+  // Built-in providers
   switch (config.provider) {
     case "claude": {
       const { createClaudeProvider } = await import("./providers/claude.js");
@@ -16,7 +22,9 @@ async function createProvider(config: RunConfig): Promise<ProviderBackend> {
       return createKimiProvider(config);
     }
     default:
-      throw new Error(`Unknown provider: ${config.provider}. Use: claude, codex, kimi`);
+      throw new Error(
+        `Unknown provider: ${config.provider}. Use: claude, codex, kimi, or register a custom provider with registerProvider()`,
+      );
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,8 +45,11 @@ export type StreamChunk =
       usage?: { inputTokens: number; outputTokens: number };
     };
 
-/** Supported provider backends */
-export type Provider = "claude" | "codex" | "kimi";
+/** Built-in provider backends */
+export type BuiltinProvider = "claude" | "codex" | "kimi";
+
+/** Supported provider backends (built-in + registered) */
+export type Provider = BuiltinProvider | (string & {});
 
 /** Configuration for a run */
 export interface RunConfig {


### PR DESCRIPTION
## Summary

- Adds `registerProvider(name, factory)` to register custom provider backends without forking the SDK
- Registry is checked before the built-in switch statement in `createProvider()`
- `Provider` type is now extensible: `BuiltinProvider | (string & {})` — preserves autocomplete for built-in names while allowing any string
- Exports `registerProvider`, `clearProviders`, `ProviderFactory`, `BuiltinProvider`

## Example

```typescript
import { registerProvider, run } from "one-agent-sdk";

registerProvider("gemini", async (config) => { /* ... */ });

const { stream } = await run("Hello", {
  provider: "gemini", // works now
  agent,
});
```

## Test plan

- [x] Custom provider is used when registered
- [x] Built-in providers still work
- [x] Unknown provider throws helpful error mentioning `registerProvider()`
- [x] `clearProviders()` removes all registered providers
- [x] Custom provider can override built-in names
- [x] End-to-end `run()` works with registered mock provider
- [x] `bun run ci` passes (32 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)