### PR TITLE
chore: add npm discoverability metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,19 @@
 {
   "name": "one-agent-sdk",
   "version": "0.1.5",
+  "description": "Provider-agnostic SDK for building LLM agents — one API for Claude, Codex, and Kimi",
+  "keywords": [
+    "ai",
+    "agent",
+    "llm",
+    "claude",
+    "openai",
+    "codex",
+    "kimi",
+    "streaming",
+    "tools",
+    "typescript"
+  ],
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Add `description` and `keywords` fields to `package.json` to improve npm search discoverability
- Keywords cover key terms: ai, agent, llm, provider names (claude, openai, codex, kimi), streaming, tools, typescript

## Test plan
- [ ] Verify `npm info one-agent-sdk` shows description and keywords after next publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)