### PR TITLE
feat: add create-one-agent scaffolding CLI

### DIFF
--- a/create-one-agent/MARKETING.md
+++ b/create-one-agent/MARKETING.md
@@ -1,0 +1,78 @@
+# Marketing Drafts
+
+## Tweet (English)
+
+One Agent SDK — write your AI agent once, run it on Claude Code, Codex, or Kimi.
+
+- Streaming-first (AsyncGenerator)
+- Type-safe tools with Zod
+- Multi-agent handoffs
+- Composable middleware
+
+Get started in 30 seconds:
+npx create-one-agent my-app
+
+https://github.com/odysa/one-agent-sdk
+
+---
+
+## Tweet (Chinese)
+
+One Agent SDK — 一套代码适配所有 LLM Agent 后端。
+
+写一次 agent，换一行 provider 就能跑 Claude Code / Codex / Kimi：
+- Streaming-first，统一 AsyncGenerator 接口
+- Zod 定义工具，类型安全
+- 多 Agent 协作 handoff
+- 可组合的中间件系统
+
+30 秒上手：
+npx create-one-agent my-app
+
+https://github.com/odysa/one-agent-sdk
+
+---
+
+## Show HN
+
+### Title
+
+Show HN: One Agent SDK – Write your AI agent once, run on Claude Code, Codex, or Kimi
+
+### Body
+
+Hi HN,
+
+I built One Agent SDK because I got tired of rewriting the same agent logic every time I switched LLM providers. Each SDK has its own streaming format, tool-calling API, and agent patterns — so your code is locked in from day one.
+
+One Agent SDK gives you a single TypeScript interface. Write your agents, tools, and orchestration once, then swap backends by changing one string:
+
+```typescript
+const { stream } = await run("Analyze this code", {
+  provider: "claude-code",  // or "codex" or "kimi-cli"
+  agent,
+});
+```
+
+Key design decisions:
+
+**Streaming-first.** Every provider returns `AsyncGenerator<StreamChunk>` — a unified discriminated union of text, tool_call, tool_result, handoff, error, and done events. No callbacks, no event emitters — just a for-await loop.
+
+**Type-safe tools with Zod.** Define tool parameters with Zod schemas. The SDK converts them to whatever format each provider needs (MCP server for Claude, JSON Schema for Codex, createExternalTool for Kimi).
+
+**Multi-agent handoffs.** Agents declare who they can hand off to. The SDK handles routing — Claude's built-in agent support, synthetic transfer_to_X tools for Codex/Kimi — all transparent to your code.
+
+**Composable middleware.** AsyncGenerator transforms that sit between the provider and your app. Ships with logging, usage tracking, timing, guardrails, and hooks. Write your own in ~5 lines.
+
+**Zero lock-in.** Provider SDKs are optional peer deps, dynamically imported at runtime. Install only what you need.
+
+Try it:
+
+```
+npx create-one-agent my-app
+cd my-app && npm install && npm start
+```
+
+GitHub: https://github.com/odysa/one-agent-sdk
+
+Would love feedback on the API design, especially from anyone who's been wrangling multiple agent SDKs. What's missing? What would make you actually switch?

--- a/create-one-agent/index.mjs
+++ b/create-one-agent/index.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { basename, join, resolve } from "node:path";
+import { createInterface } from "node:readline";
+
+const rl = createInterface({ input: process.stdin, output: process.stdout });
+const ask = (q) => new Promise((r) => rl.question(q, r));
+
+const PROVIDERS = {
+  "claude-code": "@anthropic-ai/claude-agent-sdk",
+  codex: "@openai/codex-sdk",
+  "kimi-cli": "@moonshot-ai/kimi-agent-sdk",
+};
+
+const PROVIDER_LABELS = {
+  "claude-code": "Claude Code",
+  codex: "ChatGPT Codex",
+  "kimi-cli": "Kimi CLI",
+};
+
+async function main() {
+  // Accept project name as positional arg or prompt
+  let name = process.argv[2];
+
+  console.log();
+  console.log("  Create One Agent");
+  console.log("  ~~~~~~~~~~~~~~~~");
+  console.log();
+
+  if (!name) {
+    name = (await ask("  Project name (my-agent): ")).trim() || "my-agent";
+  }
+
+  console.log();
+  console.log("  Providers:");
+  console.log("    1. claude-code  (Claude Code)");
+  console.log("    2. codex        (ChatGPT Codex)");
+  console.log("    3. kimi-cli     (Kimi CLI)");
+  console.log();
+
+  const choice = (await ask("  Choose provider [1]: ")).trim() || "1";
+  const provider =
+    ["claude-code", "codex", "kimi-cli"][Number(choice) - 1] || "claude-code";
+  const providerPkg = PROVIDERS[provider];
+
+  rl.close();
+
+  const dir = resolve(process.cwd(), name);
+  await mkdir(dir, { recursive: true });
+
+  // package.json
+  await writeFile(
+    join(dir, "package.json"),
+    JSON.stringify(
+      {
+        name: basename(name),
+        version: "0.1.0",
+        type: "module",
+        private: true,
+        scripts: {
+          start: "npx tsx index.ts",
+        },
+        dependencies: {
+          "one-agent-sdk": "^0.1.5",
+          [providerPkg]: "latest",
+          zod: "^4.0.0",
+        },
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+
+  // index.ts
+  await writeFile(
+    join(dir, "index.ts"),
+    `import { z } from "zod";
+import { defineAgent, defineTool, run } from "one-agent-sdk";
+
+const weatherTool = defineTool({
+  name: "get_weather",
+  description: "Get current weather for a city",
+  parameters: z.object({
+    city: z.string().describe("City name"),
+  }),
+  handler: async ({ city }) => {
+    return JSON.stringify({ city, temp: 72, condition: "sunny" });
+  },
+});
+
+const agent = defineAgent({
+  name: "assistant",
+  description: "A helpful assistant",
+  prompt: "You are a helpful assistant. Use tools when needed.",
+  tools: [weatherTool],
+});
+
+const { stream } = await run("What's the weather in San Francisco?", {
+  provider: "${provider}",
+  agent,
+});
+
+for await (const chunk of stream) {
+  if (chunk.type === "text") process.stdout.write(chunk.text);
+}
+console.log();
+`,
+  );
+
+  // tsconfig.json (minimal, for editor support)
+  await writeFile(
+    join(dir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: "ES2022",
+          module: "Node16",
+          moduleResolution: "Node16",
+          strict: true,
+          skipLibCheck: true,
+        },
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+
+  console.log();
+  console.log(`  Done! Created ${name}/`);
+  console.log();
+  console.log(`    cd ${name}`);
+  console.log("    npm install");
+  console.log("    npm start");
+  console.log();
+  console.log(
+    `  Using ${PROVIDER_LABELS[provider]} — make sure its CLI is installed and authenticated.`,
+  );
+  console.log(
+    "  To switch providers, just change the provider string in index.ts.",
+  );
+  console.log();
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/create-one-agent/package.json
+++ b/create-one-agent/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "create-one-agent",
+  "version": "0.1.0",
+  "description": "Scaffold a One Agent SDK project in seconds",
+  "type": "module",
+  "bin": {
+    "create-one-agent": "./index.mjs"
+  },
+  "files": [
+    "index.mjs"
+  ],
+  "keywords": [
+    "agent",
+    "llm",
+    "claude",
+    "codex",
+    "kimi",
+    "scaffold",
+    "create"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/odysa/one-agent-sdk",
+    "directory": "create-one-agent"
+  }
+}


### PR DESCRIPTION
## Summary

- Add `npx create-one-agent` CLI — zero-dependency scaffolding tool that creates a working One Agent SDK project in 30 seconds
- Interactive provider picker (Claude Code / Codex / Kimi CLI), generates `index.ts` with tool + agent + streaming loop
- Include draft marketing copy (tweet EN/CN + Show HN post) in `MARKETING.md`

## Usage

```
npx create-one-agent my-app
cd my-app && npm install && npm start
```

## Follow-up

- [ ] Publish `create-one-agent` to npm
- [ ] Update root README Getting Started to reference `npx create-one-agent`

## Test plan

- [x] Ran CLI locally, verified generated project structure (package.json, index.ts, tsconfig.json)
- [ ] Publish dry-run: `cd create-one-agent && npm publish --dry-run`
- [ ] End-to-end: scaffold project, install deps, run with a real provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)