### PR TITLE
docs: fix stale provider names, eval() security issue, and missing types

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,11 +194,11 @@ import { createSession } from "one-agent-sdk";
 
 const session = createSession();
 
-const first = await session.run("My name is Alice.", { provider: "claude", agent });
+const first = await session.run("My name is Alice.", { provider: "claude-code", agent });
 for await (const chunk of first.stream) { /* ... */ }
 
 // The agent remembers the previous turn
-const second = await session.run("What's my name?", { provider: "claude", agent });
+const second = await session.run("What's my name?", { provider: "claude-code", agent });
 for await (const chunk of second.stream) { /* ... */ }
 ```
 

--- a/docs/api/types.md
+++ b/docs/api/types.md
@@ -155,6 +155,18 @@ interface SessionStore {
 }
 ```
 
+## SessionConfig
+
+Configuration options for `createSession()`.
+
+```typescript
+interface SessionConfig {
+  sessionId?: string;
+  store?: SessionStore;
+  runner?: (prompt: string, config: RunConfig) => Promise<AgentRun>;
+}
+```
+
 ## ProviderBackend
 
 Interface that provider implementations must satisfy.
@@ -173,4 +185,12 @@ Factory function for custom providers.
 
 ```typescript
 type ProviderFactory = (config: RunConfig) => Promise<ProviderBackend>;
+```
+
+## zodToJsonSchema
+
+Converts a Zod schema to JSON Schema. Used internally by providers that need JSON Schema (Codex, Kimi), but also exported for custom provider authors.
+
+```typescript
+function zodToJsonSchema(schema: z.ZodType): Record<string, unknown>;
 ```

--- a/docs/guide/handoffs.md
+++ b/docs/guide/handoffs.md
@@ -25,7 +25,16 @@ const calculatorTool = defineTool({
   name: "calculate",
   description: "Evaluate a math expression",
   parameters: z.object({ expression: z.string() }),
-  handler: async ({ expression }) => String(eval(expression)),
+  handler: async ({ expression }) => {
+    const match = expression.match(/^([\d.]+)\s*([+\-*/])\s*([\d.]+)$/);
+    if (!match) return "Error: only simple expressions like '2 + 3' are supported";
+    const [, a, op, b] = match;
+    const ops: Record<string, (a: number, b: number) => number> = {
+      "+": (a, b) => a + b, "-": (a, b) => a - b,
+      "*": (a, b) => a * b, "/": (a, b) => a / b,
+    };
+    return String(ops[op](Number(a), Number(b)));
+  },
 });
 
 const researcher = defineAgent({

--- a/docs/guide/what-is-one-agent-sdk.md
+++ b/docs/guide/what-is-one-agent-sdk.md
@@ -19,9 +19,9 @@ Each LLM provider has its own SDK with different APIs, streaming formats, and to
 
 | Provider | SDK | Agent Backend |
 | -------- | --- | ------------- |
-| `claude` | `@anthropic-ai/claude-agent-sdk` | Claude Code |
+| `claude-code` | `@anthropic-ai/claude-agent-sdk` | Claude Code |
 | `codex` | `@openai/codex-sdk` | ChatGPT Codex |
-| `kimi` | `@moonshot-ai/kimi-agent-sdk` | Kimi-CLI |
+| `kimi-cli` | `@moonshot-ai/kimi-agent-sdk` | Kimi-CLI |
 
 All providers are optional peer dependencies — install only the ones you need. You can also [register custom providers](/guide/providers#custom-providers).
 


### PR DESCRIPTION
## Summary

- **Fix stale provider names**: `"claude"` → `"claude-code"` in README sessions example, `claude`/`kimi` → `claude-code`/`kimi-cli` in the "What is One Agent SDK?" provider table (missed during the rename in #26)
- **Fix security issue**: Replace unsafe `eval()` with safe regex-based calculator in the handoffs guide example (matches the actual `examples/multi-agent.ts` implementation)
- **Add missing types to API reference**: `SessionConfig` (exported but not in types.md) and `zodToJsonSchema` utility function (exported but undocumented)

## Test plan

- [ ] Verify all provider name strings in docs match `BuiltinProvider` type: `"claude-code" | "codex" | "kimi-cli"`
- [ ] Verify handoffs guide calculator example is safe and functional
- [ ] Verify `SessionConfig` and `zodToJsonSchema` appear correctly in the types reference page
- [ ] Run `bun run ci` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)