### PR TITLE
feat: add copilot provider wrapping @github/copilot-sdk

### DIFF
--- a/examples/copilot.ts
+++ b/examples/copilot.ts
@@ -1,0 +1,43 @@
+import { defineAgent, run } from "../src/index.js";
+
+const agent = defineAgent({
+  name: "assistant",
+  description: "A helpful coding assistant",
+  prompt: "You are a helpful coding assistant.",
+});
+
+async function main() {
+  console.log("Running copilot example...");
+
+  const { stream, close } = await run("List the files in the current directory", {
+    provider: "copilot",
+    agent,
+  });
+
+  for await (const chunk of stream) {
+    switch (chunk.type) {
+      case "text":
+        process.stdout.write(chunk.text);
+        break;
+      case "tool_call":
+        console.log(`\n[tool call] ${chunk.toolName}(${JSON.stringify(chunk.toolArgs)})`);
+        break;
+      case "tool_result":
+        console.log(`[tool result] ${chunk.result}`);
+        break;
+      case "done":
+        console.log("\n[done]");
+        if (chunk.usage) {
+          console.log(`[usage] input: ${chunk.usage.inputTokens}, output: ${chunk.usage.outputTokens}`);
+        }
+        break;
+      case "error":
+        console.error(`[error] ${chunk.error}`);
+        break;
+    }
+  }
+
+  await close();
+}
+
+main().catch(console.error);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "one-agent-sdk",
   "version": "0.1.6",
-  "description": "Provider-agnostic SDK for building LLM agents — one API for Claude, Codex, and Kimi",
+  "description": "Provider-agnostic SDK for building LLM agents — one API for Claude, Codex, Copilot, and Kimi",
   "keywords": [
     "ai",
     "agent",
@@ -9,6 +9,7 @@
     "claude",
     "openai",
     "codex",
+    "copilot",
     "kimi",
     "streaming",
     "tools",
@@ -50,11 +51,15 @@
   },
   "peerDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.68",
+    "@github/copilot-sdk": "*",
     "@moonshot-ai/kimi-agent-sdk": "*",
     "@openai/codex-sdk": "*"
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/claude-agent-sdk": {
+      "optional": true
+    },
+    "@github/copilot-sdk": {
       "optional": true
     },
     "@openai/codex-sdk": {

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -1,0 +1,202 @@
+import type { RunConfig, StreamChunk, ToolDef } from "../types.js";
+import { handoffToolName, parseHandoff } from "../utils/handoff.js";
+import { importProvider } from "../utils/import-provider.js";
+import type { ProviderBackend } from "./types.js";
+
+export async function createCopilotProvider(config: RunConfig): Promise<ProviderBackend> {
+  const { CopilotClient, defineTool, approveAll } = await importProvider(
+    "@github/copilot-sdk",
+    "bun add @github/copilot-sdk",
+  );
+
+  const agentTools = config.agent.tools ?? [];
+
+  // Map ToolDef[] to copilot-sdk tools via defineTool (both use Zod)
+  const tools = agentTools.map((t: ToolDef) =>
+    defineTool({
+      name: t.name,
+      description: t.description,
+      parameters: t.parameters,
+      handler: t.handler,
+    }),
+  );
+
+  // Add synthetic handoff tools (same pattern as kimi provider)
+  let currentAgent = config.agent;
+
+  for (const targetName of config.agent.handoffs ?? []) {
+    const targetAgent = config.agents?.[targetName];
+    tools.push(
+      defineTool({
+        name: handoffToolName(targetName),
+        description: targetAgent?.description ?? `Transfer to ${targetName}`,
+        parameters: {} as any,
+        handler: async () => `Transferred to ${targetName}`,
+      }),
+    );
+  }
+
+  // Create client
+  const clientOptions: Record<string, unknown> = {};
+  if (config.providerOptions?.cliPath) clientOptions.cliPath = config.providerOptions.cliPath;
+  if (config.providerOptions?.cliUrl) clientOptions.cliUrl = config.providerOptions.cliUrl;
+  if (config.providerOptions?.githubToken)
+    clientOptions.githubToken = config.providerOptions.githubToken;
+  if (config.providerOptions?.clientOptions) {
+    Object.assign(clientOptions, config.providerOptions.clientOptions);
+  }
+
+  const client = new CopilotClient(clientOptions);
+  await client.start();
+
+  // Create session
+  const sessionConfig: Record<string, unknown> = {
+    streaming: true,
+    tools,
+    onPermissionRequest: approveAll,
+  };
+  if (config.agent.model) sessionConfig.model = config.agent.model;
+  if (config.providerOptions?.reasoningEffort) {
+    sessionConfig.reasoningEffort = config.providerOptions.reasoningEffort;
+  }
+  if (config.agent.prompt) {
+    sessionConfig.systemMessage = { content: config.agent.prompt };
+  }
+  if (config.workDir) sessionConfig.workDir = config.workDir;
+  if (config.providerOptions?.sessionOptions) {
+    Object.assign(sessionConfig, config.providerOptions.sessionOptions);
+  }
+
+  const session = await client.createSession(sessionConfig);
+
+  // Bridge event-based streaming to AsyncGenerator
+  async function* runPrompt(prompt: string): AsyncGenerator<StreamChunk> {
+    let fullText = "";
+    let done = false;
+
+    const queue: StreamChunk[] = [];
+    let resolve: (() => void) | null = null;
+
+    function push(chunk: StreamChunk) {
+      queue.push(chunk);
+      if (resolve) {
+        resolve();
+        resolve = null;
+      }
+    }
+
+    const unsubs: (() => void)[] = [];
+
+    unsubs.push(
+      session.on("assistant.message_delta", (event: any) => {
+        const text = event.data?.deltaContent ?? "";
+        if (text) {
+          fullText += text;
+          push({ type: "text", text });
+        }
+      }),
+    );
+
+    unsubs.push(
+      session.on("tool.execution_start", (event: any) => {
+        const name = event.data?.toolName ?? "";
+        push({
+          type: "tool_call",
+          toolName: name,
+          toolArgs: (event.data?.arguments as Record<string, unknown>) ?? {},
+          toolCallId: event.data?.toolCallId ?? "",
+        });
+
+        // Check for handoff
+        const handoffTarget = parseHandoff(name);
+        if (handoffTarget) {
+          const targetAgent = config.agents?.[handoffTarget];
+          if (targetAgent) {
+            push({
+              type: "handoff",
+              fromAgent: currentAgent.name,
+              toAgent: handoffTarget,
+            });
+            currentAgent = targetAgent;
+          }
+        }
+      }),
+    );
+
+    unsubs.push(
+      session.on("tool.execution_complete", (event: any) => {
+        const result = event.data?.result?.content;
+        push({
+          type: "tool_result",
+          toolCallId: event.data?.toolCallId ?? "",
+          result: typeof result === "string" ? result : JSON.stringify(result ?? ""),
+        });
+      }),
+    );
+
+    let usage: { inputTokens: number; outputTokens: number } | undefined;
+
+    unsubs.push(
+      session.on("assistant.usage", (event: any) => {
+        if (event.data?.inputTokens != null) {
+          usage = {
+            inputTokens: event.data.inputTokens,
+            outputTokens: event.data.outputTokens ?? 0,
+          };
+        }
+      }),
+    );
+
+    unsubs.push(
+      session.on("session.error", (event: any) => {
+        push({ type: "error", error: event.data?.message ?? "Unknown error" });
+        push({ type: "done", text: fullText, usage });
+        done = true;
+      }),
+    );
+
+    unsubs.push(
+      session.on("session.idle", () => {
+        push({ type: "done", text: fullText, usage });
+        done = true;
+      }),
+    );
+
+    if (config.signal) {
+      const onAbort = () => session.abort();
+      config.signal.addEventListener("abort", onAbort, { once: true });
+      unsubs.push(() => config.signal?.removeEventListener("abort", onAbort));
+    }
+
+    // Send the prompt
+    await session.send({ prompt });
+
+    // Yield chunks as they arrive
+    try {
+      while (!done || queue.length > 0) {
+        if (queue.length > 0) {
+          const chunk = queue.shift();
+          if (chunk) yield chunk;
+        } else if (!done) {
+          await new Promise<void>((r) => {
+            resolve = r;
+          });
+        }
+      }
+    } finally {
+      for (const unsub of unsubs) unsub();
+    }
+  }
+
+  return {
+    run: runPrompt,
+    chat: runPrompt,
+    async close() {
+      try {
+        await session.destroy();
+      } finally {
+        await client.stop();
+      }
+    },
+  };
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -24,9 +24,13 @@ async function createProvider(config: RunConfig): Promise<ProviderBackend> {
       const { createKimiProvider } = await import("./providers/kimi.js");
       return createKimiProvider(config);
     }
+    case "copilot": {
+      const { createCopilotProvider } = await import("./providers/copilot.js");
+      return createCopilotProvider(config);
+    }
     default:
       throw new Error(
-        `Unknown provider: ${config.provider}. Use: claude-code, codex, kimi-cli, or register a custom provider with registerProvider()`,
+        `Unknown provider: ${config.provider}. Use: claude-code, codex, copilot, kimi-cli, or register a custom provider with registerProvider()`,
       );
   }
 }

--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -33,3 +33,32 @@ declare module "@moonshot-ai/kimi-agent-sdk" {
   export function createSession(options: any): any;
   export function createExternalTool(options: any): any;
 }
+
+declare module "@github/copilot-sdk" {
+  class CopilotClient {
+    constructor(options?: Record<string, unknown>);
+    start(): Promise<void>;
+    stop(): Promise<Error[]>;
+    createSession(config?: Record<string, unknown>): Promise<CopilotSession>;
+  }
+  class CopilotSession {
+    sessionId: string;
+    send(options: { prompt: string }): Promise<string>;
+    sendAndWait(
+      options: { prompt: string },
+      timeout?: number,
+    ): Promise<{ data: { content: string } } | undefined>;
+    on(eventType: string, handler: (event: any) => void): () => void;
+    on(handler: (event: any) => void): () => void;
+    abort(): Promise<void>;
+    destroy(): Promise<void>;
+  }
+  function defineTool(options: {
+    name: string;
+    description: string;
+    parameters: any;
+    handler: (args: any) => Promise<any>;
+  }): any;
+  function approveAll(request: any): any;
+  export { CopilotClient, CopilotSession, defineTool, approveAll };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,7 @@ export type StreamChunk =
     };
 
 /** Built-in provider backends */
-export type BuiltinProvider = "claude-code" | "codex" | "kimi-cli";
+export type BuiltinProvider = "claude-code" | "codex" | "copilot" | "kimi-cli";
 
 /** Supported provider backends (built-in + registered) */
 export type Provider = BuiltinProvider | (string & {});


### PR DESCRIPTION
## Summary

- Adds a `copilot` provider that wraps `@github/copilot-sdk` (the TypeScript SDK for programmatic control of GitHub Copilot CLI)
- Follows the same pattern as existing `claude-code`, `codex`, and `kimi-cli` providers
- Maps user-defined tools directly via `defineTool()` (both use Zod schemas)
- Bridges the SDK's event-based streaming to `AsyncGenerator<StreamChunk>`
- Supports handoffs via synthetic `transfer_to_{name}` tools
- Includes AbortSignal support, usage tracking, and provider options passthrough

## Files changed

- `src/providers/copilot.ts` — new provider implementation
- `src/types.ts` — add `"copilot"` to `BuiltinProvider` union
- `src/runner.ts` — add `case "copilot"` to provider switch
- `src/shims.d.ts` — ambient type declarations for `@github/copilot-sdk`
- `package.json` — `@github/copilot-sdk` as optional peer dependency
- `examples/copilot.ts` — usage example

## Test plan

- [x] `bun run ci` passes (type check + lint + 96 tests)
- [x] `bun run build` produces `dist/providers/copilot.{js,d.ts}`
- [x] `bun run examples/copilot.ts` works end-to-end (streaming text, tool calls, tool results, usage tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)