### PR TITLE
docs: add Python SDK reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/odysa/one-agent-sdk/ci.yml?style=flat-square&label=CI)](https://github.com/odysa/one-agent-sdk/actions/workflows/ci.yml)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.8-3178c6?style=flat-square&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green?style=flat-square)](https://opensource.org/licenses/MIT)
+[![Python SDK](https://img.shields.io/badge/Python_SDK-3776AB?style=flat-square&logo=python&logoColor=white)](https://github.com/odysa/one-agent-sdk-python)
 
 **Drop-in replacement for `@anthropic-ai/claude-agent-sdk` — same API, multiple providers.**
 
@@ -290,6 +291,23 @@ The following functions are exported from `one-agent-sdk` and will be removed in
 | `runToCompletion(prompt, config)` | `query({ prompt, options })` + collect results |
 | `defineAgent({...})` | Pass agent config directly via `query()` options |
 | `defineTool({...})` | `tool(name, description, schema, handler)` |
+
+<br />
+
+## Python SDK
+
+Looking for Python? See **[one-agent-sdk-python](https://github.com/odysa/one-agent-sdk-python)** — same API, same providers, pure Python.
+
+```bash
+pip install one-agent-sdk
+```
+
+```python
+from one_agent_sdk import query, ClaudeAgentOptions
+
+async for msg in query(prompt="Hello", options=ClaudeAgentOptions(provider="codex")):
+    print(msg)
+```
 
 <br />
 


### PR DESCRIPTION
## Summary
- Add a Python SDK badge in the header linking to [one-agent-sdk-python](https://github.com/odysa/one-agent-sdk-python)
- Add a "Python SDK" section before Contributing with install command and quick usage example

## Context
The Python port (`one-agent-sdk-python`) is now published with full feature parity — same providers, middleware, sessions, and SDK-compatible message types. This PR cross-references it from the TypeScript README so users can find the right package for their language.